### PR TITLE
feat: new 'ergo' layouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,6 @@
         <option value="iso">        ISO   </option>
         <option value="ansi">       ANSI  </option>
         <option value="ol60">       60%   </option>
-        <option value="ol50">       50%   </option>
         <option value="ol40">       40%   </option>
       </select>
       <select id="platform">

--- a/src/content.js
+++ b/src/content.js
@@ -221,7 +221,6 @@ const numberRow =
     gKey('pinkyKey', 'l5', 0, 'Backquote', [
       rect('specialKey jis', { width: 1 }),
       rect('ansi alt iso', { width: 1 }),
-      rect('ol60', { width: 1.25 }),
       text('半角', 'jis', { x: 0.5, y: 0.4 }), // half-width (hankaku)
       text('全角', 'jis', { x: 0.5, y: 0.6 }), // full-width (zenkaku)
       text('漢字', 'jis', { x: 0.5, y: 0.8 }), // kanji
@@ -240,16 +239,11 @@ const numberRow =
     gKey('numberKey', 'r4', 9, 'Digit9'),
     gKey('numberKey', 'r5', 10, 'Digit0'),
     gKey('pinkyKey', 'r5', 11, 'Minus'),
-    gKey('pinkyKey', 'r5', 12, 'Equal', [
-      rect('ansi', { width: 1.0 }),
-      rect('ol60', { width: 1.25 }),
-      g('key'),
-    ]),
+    gKey('pinkyKey', 'r5', 12, 'Equal'),
     gKey('pinkyKey', 'r5', 13, 'IntlYen'),
     gKey('specialKey', 'r5', 13, 'Backspace', [
       rect('ansi', { width: 2 }),
-      rect('ol60', { width: 1.25, height: 2, y: -1 }),
-      rect('ol40 ol50', { width: 1.25 }),
+      rect('ergo', { width: 1.25 }),
       rect('alt', { x: 1 }),
       text('⌫', 'ansi'),
       text('⌫', 'ergo'),
@@ -261,9 +255,11 @@ const letterRow1 =
   g('left', [
     gKey('specialKey', 'l5', 0, 'Tab', [
       rect('', { width: 1.5 }),
-      rect('ergo', { width: 1.25 }),
+      rect('ol40', { width: 1.25 }),
+      rect('ol60', { width: 1, x: 0.25 }),
       text('↹'),
-      text('↹', 'ergo'),
+      text('↹', 'ol40'),
+      text('↹', 'ol60', { translateX: 0.25 }),
     ]),
     gKey('letterKey', 'l5', 1.5, 'KeyQ'),
     gKey('letterKey', 'l4', 2.5, 'KeyW'),
@@ -278,11 +274,7 @@ const letterRow1 =
     gKey('letterKey', 'r4', 9.5, 'KeyO'),
     gKey('letterKey', 'r5', 10.5, 'KeyP'),
     gKey('pinkyKey', 'r5', 11.5, 'BracketLeft'),
-    gKey('pinkyKey', 'r5', 12.5, 'BracketRight', [
-      rect('ansi', { width: 1.0 }),
-      rect('ol60', { width: 1.25 }),
-      g('key'),
-    ]),
+    gKey('pinkyKey', 'r5', 12.5, 'BracketRight'),
     gKey('pinkyKey', 'r5', 13.5, 'Backslash', [
       rect('ansi', { width: 1.5 }),
       rect('iso ol60'),
@@ -314,8 +306,7 @@ const letterRow2 =
       path('alt', altEnterPath),
       path('iso', isoEnterPath),
       rect('ansi', { width: 2.25 }),
-      rect('ol60', { width: 1.25, height: 2, y: -1 }),
-      rect('ol40 ol50', { width: 1.25 }),
+      rect('ergo', { width: 1.25 }),
       text('⏎', 'ansi alt ergo'),
       text('⏎', 'iso', { translateX: 1 }),
     ]),
@@ -326,8 +317,7 @@ const letterRow3 =
     gKey('specialKey', 'l5', 0, 'ShiftLeft', [
       rect('ansi alt', { width: 2.25 }),
       rect('iso', { width: 1.25 }),
-      rect('ol50 ol60', { width: 1.25, height: 2, y: -1 }),
-      rect('ol40', { width: 1.25 }),
+      rect('ergo', { width: 1.25 }),
       text('⇧'),
       text('⇧', 'ergo'),
     ]),
@@ -348,10 +338,7 @@ const letterRow3 =
     gKey('specialKey', 'r5', 12.25, 'ShiftRight', [
       rect('ansi', { width: 2.75 }),
       rect('abnt', { width: 1.75, x: 1 }),
-      rect('ol50 ol60', { width: 1.25, height: 2, y: -1 }),
-      rect('ol40', { width: 1.25 }),
       text('⇧', 'ansi'),
-      text('⇧', 'ergo'),
       text('⇧', 'abnt', { translateX: 1 }),
     ]),
   ]);
@@ -390,7 +377,7 @@ const baseRow =
   gKey('homeKey', 'm1', 3.75, 'Space', [
     rect('ansi', { width: 6.25 }),
     rect('ol60', { width: 5.5, x: -1 }),
-    rect('ol50 ol40', { width: 4.5 }),
+    rect('ol40', { width: 4.5 }),
     rect('ks', { width: 4.25, x: 1 }),
     rect('jis', { width: 3.25, x: 1 }),
   ]) +
@@ -417,20 +404,16 @@ const baseRow =
     ]),
     gKey('specialKey', 'r1', 11.5, 'MetaRight', [
       rect('', { width: 1.25 }),
-      rect('ergo', { width: 1.5 }),
       text('Win', 'win', nonIcon),
       text('Super', 'gnu', nonIcon),
       text('⌘', 'mac'),
     ]),
     gKey('specialKey', 'r5', 12.5, 'ContextMenu', [
       rect('', { width: 1.25 }),
-      rect('ergo'),
       text('☰'),
-      text('☰', 'ol60'),
     ]),
     gKey('specialKey', 'r5', 13.75, 'ControlRight', [
       rect('', { width: 1.25 }),
-      rect('ergo', { width: 1.25 }),
       text('Ctrl', 'win gnu', nonIcon),
       text('⌃', 'mac'),
     ]),

--- a/src/style.js
+++ b/src/style.js
@@ -98,10 +98,8 @@ const classicGeometry = `
 const orthoGeometry = `
   .specialKey   .ergo,
   .specialKey   .ol60,
-  .specialKey   .ol50,
   .specialKey   .ol40,
   #Space        .ol60,
-  #Space        .ol50,
   #Space        .ol40,
   #Backquote    .ol60,
   #BracketRight .ol60,
@@ -111,58 +109,60 @@ const orthoGeometry = `
   .ergo #Backslash  rect,
   .ergo .specialKey rect,
   .ergo .specialKey text { display: none; }
-  .ol50 #Escape,
-  .ol40 #Escape,
+  .ergo #Escape,
   .ol60 #Space        .ol60,
-  .ol50 #Space        .ol50,
   .ol40 #Space        .ol40,
   .ol60 #Backquote    .ol60,
   .ol60 #BracketRight .ol60,
   .ol60 #Backslash    .ol60,
   .ol60 #Equal        .ol60,
   .ol60 .specialKey   .ol60,
-  .ol50 .specialKey   .ol50,
   .ol40 .specialKey   .ol40,
   .ergo .specialKey   .ergo { display: block; }
 
-  .ol50 .pinkyKey, .ol50 #ContextMenu,
-  .ol40 .pinkyKey, .ol40 #ContextMenu,
+  .ol40 .pinkyKey,
   .ol40 #row_AE .numberKey { display: none; }
 
-  .ergo #row_AE       ${translate(1.5, 0, true)}
-  .ergo #row_AD       ${translate(1.0, 1, true)}
-  .ergo #row_AC       ${translate(0.75, 2, true)}
-  .ergo #row_AB       ${translate(0.25, 3, true)}
+  .ol60 #row_AE ${translate(1.50, 0, true)}
+  .ol60 #row_AD ${translate(1.00, 1, true)}
+  .ol60 #row_AC ${translate(0.75, 2, true)}
+  .ol60 #row_AB ${translate(0.25, 3, true)}
 
-  .ergo #Tab          ${translate(0.25)}
-  .ergo #ShiftLeft    ${translate(1.0)}
-  .ergo #ControlLeft  ${translate(1.25)}
-  .ergo #MetaLeft     ${translate(2.5)}
-  .ergo #AltLeft      ${translate(4.0)}
-  .ergo #Space        ${translate(5.25)}
-  .ergo #AltRight     ${translate(9.0)}
-  .ergo #MetaRight    ${translate(10.5)}
-  .ergo #ControlRight ${translate(12.5)}
+  .ol40 #row_AD ${translate(0.875, 0.5, true)}
+  .ol40 #row_AC ${translate(0.625, 1.5, true)}
+  .ol40 #row_AB ${translate(0.125, 2.5, true)}
+  .ol40 #row_AA ${translate(-0.125, 3.5, true)}
 
   .ergo .left         ${translate(-0.25)}
   .ergo .right        ${translate(0.25)}
+  .ergo #Space        ${translate(5.25)}
+  .ergo #ShiftLeft    ${translate(4, 1)}
+  .ergo #Tab          ${translate(0.25, 0.5)}
+  .ergo #MetaLeft,
+  .ergo #MetaRight,
+  .ergo #ControlLeft,
+  .ergo #ControlRight,
+  .ergo #ContextMenu,
+  .ergo #AltLeft,
+  .ergo #ShiftRight { display: none; }
 
   .ol60 .left         ${translate(-1.25)}
-  .ol60 #ControlRight ${translate(13.5)}
-  .ol60 #Backquote    ${translate(-0.25)}
-  .ol60 #ShiftRight   ${translate(13.25)}
-  .ol60 #ContextMenu  ${translate(12.5)}
-  .ol60 #Backslash    ${translate(11.5, 2)}
-  .ol60 #Backspace    ${translate(4.625, 1)}
-  .ol60 #Enter        ${translate(5.375, 1)}
+  .ol60 #Escape       ${translate(6.125, 0.5)}
+  .ol60 #Enter        ${translate(5.375, 0.5)}
+  .ol60 #Backspace    ${translate(4.625, 1.5)}
+  .ol60 #Backquote    ${translate(0, 0.5)}
+  .ol60 #IntlBackslash ${translate(1.25, -0.5)}
+  .ol60 #Minus        ${translate(11.0, 0.5)}
+  .ol60 #Equal        ${translate(12.0, 0.5)}
+  .ol60 #BracketLeft  ${translate(11.5, 0.5)}
+  .ol60 #BracketRight ${translate(12.5, 0.5)}
+  .ol60 #Quote        ${translate(11.75, 0.5)}
+  .ol60 #Backslash    ${translate(12.5, 1.5)}
+  .ol60 #IntlBackslash { display: block; }
 
-  .ol50 #Escape       ${translate(-0.25)}
-  .ol50 #Backspace    ${translate(11.0)}
-  .ol50 #Enter        ${translate(11.75, -1)}
-
-  .ol40 #Escape       ${translate(-0.25, 2)}
-  .ol40 #Backspace    ${translate(11.0, 1)}
-  .ol40 #Enter        ${translate(11.75, 0)}
+  .ol40 #Escape       ${translate(1.125, 2)}
+  .ol40 #Backspace    ${translate(12.375, 1)}
+  .ol40 #Enter        ${translate(11.75, 0.5)}
 
   [platform="gnu"].ergo .specialKey .win,
   [platform="gnu"].ergo .specialKey .mac,


### PR DESCRIPTION
- the 'ol60' layout matches the TMx and the QMx
- the 'ol40' layout matches the Owl and Arsenik
- the 'ol50' layout is dropped