### PR TITLE
fix: ANSI-style finger assignment

### DIFF
--- a/src/x-keyboard.js
+++ b/src/x-keyboard.js
@@ -6,15 +6,6 @@ import css from './style.js';
  * Custom Element
  */
 
-const setFingerAssignment = (root, ansiStyle) => {
-  (ansiStyle
-    ? ['l5', 'l4', 'l3', 'l2', 'l2', 'r2', 'r2', 'r3', 'r4', 'r5']
-    : ['l5', 'l5', 'l4', 'l3', 'l2', 'l2', 'r2', 'r2', 'r3', 'r4']
-  ).forEach((attr, i) => {
-    root.getElementById(`Digit${(i + 1) % 10}`).setAttribute('finger', attr);
-  });
-};
-
 const getKeyChord = (root, key) => {
   if (!key || !key.id) {
     return [];
@@ -168,7 +159,6 @@ class Keyboard extends HTMLElement {
       classes.forEach(cls => svg.classList.remove(cls)),
     );
     shape.forEach(cls => svg.classList.add(cls));
-    setFingerAssignment(this.root, !shape.includes('iso'));
   }
 
   get platform() {


### PR DESCRIPTION
This drops a common finger assignment in Europe, where [2] is pressed with the pinky instead of the ring finger. It's a bummer in AZERTY (the `é` is a very common letter in French), and it's a pain when learning ortholinear keyboards later on.

/cc @Ashenfae 